### PR TITLE
lower the aggregated api group priority

### DIFF
--- a/templates/multiclusterhub/base/apiserver/apiservice-clusterview_v1.yaml
+++ b/templates/multiclusterhub/base/apiserver/apiservice-clusterview_v1.yaml
@@ -11,5 +11,5 @@ spec:
     namespace: open-cluster-management
     name: ocm-proxyserver
   insecureSkipTLSVerify: true
-  groupPriorityMinimum: 10000
+  groupPriorityMinimum: 10
   versionPriority: 20

--- a/templates/multiclusterhub/base/apiserver/apiservice-clusterview_v1alpha1.yaml
+++ b/templates/multiclusterhub/base/apiserver/apiservice-clusterview_v1alpha1.yaml
@@ -11,5 +11,5 @@ spec:
     namespace: open-cluster-management
     name: ocm-proxyserver
   insecureSkipTLSVerify: true
-  groupPriorityMinimum: 10000
+  groupPriorityMinimum: 10
   versionPriority: 20


### PR DESCRIPTION
story: https://github.com/open-cluster-management/backlog/issues/9691
The aggregated api group `clusterview.open-cluster-management.io` has the same resources `managedCluster` and 
`managedClusterSet` with the group `cluster.open-cluster-management.io` . 
Lower the priority of group `clusterview.open-cluster-management.io` to make sure that the resources in group `cluster.open-cluster-management.io` could be preferred by client, like  `oc get managedcluster/managedclusterset`.
