### PR TITLE
Have gather script look only in crds directory

### DIFF
--- a/cicd-scripts/gather-crds.sh
+++ b/cicd-scripts/gather-crds.sh
@@ -73,7 +73,7 @@ if [[ $? -ne 0 ]]; then
    exit 3
 fi
 
-find "$clone_to_spot" -name '*.yaml' -print0 | xargs -I '{}' -0 cp '{}' "$dest_dir"
+find "$clone_to_spot/crds" -name '*.yaml' -print0 | xargs -I '{}' -0 cp '{}' "$dest_dir"
 
 # Clean up our temp stuff.
 


### PR DESCRIPTION
The gather-crdsd script was unintentionally picking up non-CRD YAML files.  This change constrains it to look only within the `crds` directory tree.