### PR TITLE
Update AppSub Version Check

### DIFF
--- a/pkg/controller/multiclusterhub/common.go
+++ b/pkg/controller/multiclusterhub/common.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	e "errors"
 	"fmt"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"reflect"
+	"strings"
+
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	"time"
 
@@ -631,7 +633,7 @@ func (r *ReconcileMultiClusterHub) ensureSubscriptionOperatorIsRunning(mch *oper
 	}
 
 	// skip check if not deployed by OLM
-	if !isOLMManaged(selfDeployment) {
+	if !isACMManaged(selfDeployment) {
 		return nil, nil
 	}
 
@@ -660,14 +662,16 @@ func (r *ReconcileMultiClusterHub) ensureSubscriptionOperatorIsRunning(mch *oper
 	}
 }
 
-// isOLMManaged returns whether this application is managed by OLM
-func isOLMManaged(deploy *appsv1.Deployment) bool {
+// isACMManaged returns whether this application is managed by OLM via an ACM subscription
+func isACMManaged(deploy *appsv1.Deployment) bool {
 	labels := deploy.GetLabels()
 	if labels == nil {
 		return false
 	}
-	if _, ok := labels["olm.owner"]; ok {
-		return true
+	if owner, ok := labels["olm.owner"]; ok {
+		if strings.Contains(owner, "advanced-cluster-management") {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/controller/multiclusterhub/common_test.go
+++ b/pkg/controller/multiclusterhub/common_test.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package multiclusterhub
 
 import (
@@ -822,7 +821,7 @@ func Test_getDeploymentByName(t *testing.T) {
 	}
 }
 
-func Test_isOLMManaged(t *testing.T) {
+func Test_isACMManaged(t *testing.T) {
 	foo := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	bar := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -834,6 +833,12 @@ func Test_isOLMManaged(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "olm",
 			Labels: map[string]string{"olm.owner": "foobar"},
+		},
+	}
+	acmDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "olm",
+			Labels: map[string]string{"olm.owner": "advanced-cluster-management.v2.3.0"},
 		},
 	}
 
@@ -853,14 +858,19 @@ func Test_isOLMManaged(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "OLM installed",
+			name:   "OLM managed",
 			deploy: olmDeploy,
+			want:   false,
+		},
+		{
+			name:   "OLM managed by ACM",
+			deploy: acmDeploy,
 			want:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isOLMManaged(tt.deploy); got != tt.want {
+			if got := isACMManaged(tt.deploy); got != tt.want {
 				t.Errorf("isOLMManaged() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Only check subscription operator version if installed as a composite bundle (where olm.owner is advanced-cluster-management instead of multicluster-hub)