### PR TITLE
[2.2] Allow viewer to create/delete managedclusterviews

### DIFF
--- a/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: ["view.open-cluster-management.io"]
   resources: ["managedclusterviews", "managedclusterviews/status"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: ["internal.open-cluster-management.io"]
   resources: ["managedclusterinfos", "managedclusterinfos/status"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Related issue: https://github.com/open-cluster-management/backlog/issues/11243

Console-api `getResource` query uses `ManagedClusterViews` to get resource yaml, the viewer needs to be able to create and delete `ManagedClusterViews` to perform this query.